### PR TITLE
Fix scss not being correctly compiled and missing classes

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,18 +9,15 @@
  * compiled file so the styles you add here take precedence over styles defined in any other CSS/SCSS
  * files in this directory. Styles in this file should be added after the last require_* statement.
  * It is generally better to create a new file per style scope.
+ *
+ *= require_tree .
+ *= require_self
  */
 
 @import 'bulma';
 
 $regular-background: #ffffff;
 $login-background: #f2f6fa;
-
-/*
- *
- *= require_tree .
- *= require_self
- */
 
 .hero.is-login {
   background: $login-background;

--- a/app/assets/stylesheets/recipes.scss
+++ b/app/assets/stylesheets/recipes.scss
@@ -1,6 +1,9 @@
 // Place all the styles related to the recipes controller here.
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
+
+$regular-background: #ffffff;
+
 .recipe-photo {
   background-color: $regular-background;
   height: 500px;


### PR DESCRIPTION
The lint fix in d0c66fe introduced a bug for scss which was being incorrectly compiled, resulting in missing classes (such as the recipe-photo class)