### PR TITLE
Make ellipsis work with total time in index, fix styling

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -68,7 +68,7 @@ $login-background: #f2f6fa;
   letter-spacing: -0.4px;
 }
 
-.content > .ellipsed-info {
+.content p {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: -0.4px;

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -68,8 +68,8 @@
                   </div>
                 </div>
                 <div class="content">
-                  <p class="ellipsed-info"><%= recipe.info %><br />
-                  <i class="fa fa-clock-o" aria-hidden="true" title="<%= t(".total_time") %>"></i> <%= recipe_presenter.total_time %> <%= t('units.minutes') %></p>
+                  <p class="ellipsed-info"><%= recipe.info %></p>
+                  <p><i class="fa fa-clock-o" aria-hidden="true" title="<%= t(".total_time") %>"></i> <%= recipe_presenter.total_time %> <%= t('units.minutes') %></p>
                   <p class="is-pulled-right"><small><%= l(recipe.created_at.to_date) %></small></p>
                 </div>
               </div>


### PR DESCRIPTION
The total time was being ellipsed when the information about the recipe was too long. Splits in two elements to avoid. Fix time styling.

Before / After
![image](https://user-images.githubusercontent.com/173791/49674508-88045080-fa72-11e8-8e6f-0f235e6fb778.png) ![image](https://user-images.githubusercontent.com/173791/49674547-a5391f00-fa72-11e8-9e85-2dec0d11eeae.png)

Before / After
![image](https://user-images.githubusercontent.com/173791/49674531-95b9d600-fa72-11e8-9bc1-6a06d18c770a.png) ![image](https://user-images.githubusercontent.com/173791/49674551-abc79680-fa72-11e8-8e5b-20a225f274c2.png)
