### PR TITLE
Fix subtitle style being overwritten

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -65,7 +65,7 @@ $login-background: #f2f6fa;
   letter-spacing: -0.4px;
 }
 
-.content p {
+.recipe-description p {
   font-size: 14px;
   font-weight: 400;
   letter-spacing: -0.4px;

--- a/app/views/accounts/show.html.erb
+++ b/app/views/accounts/show.html.erb
@@ -41,7 +41,7 @@
                     <p class="subtitle is-5 no-padding ellipsed-title"><%= link_to recipe.title, short_account_recipe_path(recipe.account, recipe) %></p>
                   </div>
                 </div>
-                <div class="content">
+                <div class="content recipe-description">
                   <p class="ellipsed-info"><%= recipe.info %></p>
                   <p class="is-pulled-right"><small><%= l(recipe.created_at.to_date) %></small></p>
                 </div>

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -69,7 +69,7 @@
                     <p class="subtitle is-5 no-padding ellipsed-title"><%= link_to recipe.title, short_account_recipe_path(recipe.account, recipe), title: recipe.title %></p>
                   </div>
                 </div>
-                <div class="content">
+                <div class="content recipe-description">
                   <p class="ellipsed-info"><%= recipe.info %></p>
                   <p><i class="fa fa-clock-o" aria-hidden="true" title="<%= t(".total_time") %>"></i> <%= recipe_presenter.total_time %> <%= t('units.minutes') %></p>
                   <p class="is-pulled-right"><small><%= l(recipe.created_at.to_date) %></small></p>


### PR DESCRIPTION
b07b4ab introduced a regression by using the content selector, this uses a different selector to avoid overwriting unwanted styles.