### PR TITLE
Adjust filters box on mobile

### DIFF
--- a/app/assets/javascripts/recipes.coffee
+++ b/app/assets/javascripts/recipes.coffee
@@ -27,4 +27,10 @@ document.addEventListener 'turbolinks:load', ->
     read_url this
     change_file_name this
     return
+
+  $('#toggle-filters').click ->
+
+    $('#filters-box').toggleClass("is-hidden-touch")
+    return
+
   return

--- a/app/views/recipes/index.html.erb
+++ b/app/views/recipes/index.html.erb
@@ -1,7 +1,29 @@
 <div class="container">
   <div class="section">
-    <div class="columns">
-      <div class="column is-one-quarter">
+    <div class="columns is-multiline">
+      <div class="column is-12">
+        <div class="panel">
+          <%= form_tag(recipes_path, method: 'get', local: true, class: 'control') do |form| %>
+          <% @safe_params.except(:search).each do |k, v| %>
+          <%= hidden_field_tag k, v %>
+          <% end %>
+          <div class="field has-addons">
+            <p class="control is-expanded">
+            <%= text_field_tag :search, params[:search], placeholder: 'Enter a title', class: 'input is-fullwidth' %>
+            </p>
+            <p class="control">
+            <%= submit_tag 'Search', class: 'button is-primary' %>
+            </p>
+            <p class="control is-hidden-desktop">
+            <a class="button is-outlined" id="toggle-filters" aria-label="<%= t(".toggle_filters_box") %>">
+              <span class="icon is-small"><i class="fa fa-filter"></i></span>
+            </a>
+          </p>
+          </div>
+          <% end %>
+        </div>
+      </div>
+      <div class="column is-3-desktop is-12-touch is-hidden-touch" id="filters-box">
         <nav class="panel">
           <p class="panel-heading">
           Filters
@@ -31,22 +53,7 @@
           </div>
         </nav>
       </div>
-      <div class="column is-three-quarters">
-        <div class="panel">
-          <%= form_tag(recipes_path, method: 'get', local: true, class: 'control') do |form| %>
-          <% @safe_params.except(:search).each do |k, v| %>
-          <%= hidden_field_tag k, v %>
-          <% end %>
-          <div class="field has-addons">
-            <p class="control is-expanded">
-            <%= text_field_tag :search, params[:search], placeholder: 'Enter a title', class: 'input is-fullwidth' %>
-            </p>
-            <p class="control">
-            <%= submit_tag 'Search', class: 'button is-primary' %>
-            </p>
-          </div>
-          <% end %>
-        </div>
+      <div class="column is-12-touch is-9-desktop">
         <div class="columns is-multiline">
           <% @recipes.each do |recipe| %>
           <% present(recipe) do |recipe_presenter| %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -73,6 +73,7 @@ en:
       last_modification: Last modification
     index:
       total_time: Preparation and cooking time
+      toggle_filters_box: Toggle filters
   time:
     formats:
       default: "%d/%m/%Y %H:%M"


### PR DESCRIPTION
In the mobile view filters were taking sometimes two or more pages before reaching the recipes. This moves the search to a div by itself and hide filters by default on mobile (which can then be enabled by clicking on a filtering button).

Before / After (mobile)
![image](https://user-images.githubusercontent.com/173791/50206343-64db7a00-036b-11e9-8ad8-dcef3670a61d.png) ![image](https://user-images.githubusercontent.com/173791/50206383-83417580-036b-11e9-8da7-ea62d57c8a69.png)

Before / After (desktop)
![image](https://user-images.githubusercontent.com/173791/50206414-9ce2bd00-036b-11e9-9cfd-67350e221e04.png) ![image](https://user-images.githubusercontent.com/173791/50206435-a9ffac00-036b-11e9-8c62-278bf47dda93.png)

