### PR TITLE
Refactor controller query, fix bug with private recipes

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -11,16 +11,7 @@ class RecipesController < ApplicationController
   # GET /recipes
   def index
     authorize :recipe, :index?
-    @recipes = Recipe.all
-    @recipes = if params[:sort_by] == "title"
-      @recipes.by_title
-    else
-      @recipes.by_created_at
-    end
-    @recipes = @recipes.with_public if current_user.blank?
-    @recipes = @recipes.search_for(params[:search]) if params[:search]
-    @recipes = @recipes.with_course(@course) if @course
-    @recipes = @recipes.with_cuisine(@cuisine) if @cuisine
+    @recipes = RecipeIndexQuery.new.query(params[:sort_by], current_user, params[:search], @course, @cuisine)
     @recipes = @recipes.page params[:page]
     @courses = Course.all.with_recipes_count
     @cuisines = Cuisine.all.with_recipes_count

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -31,6 +31,7 @@ class Recipe < ApplicationRecord
   scope :by_title, -> { order(title: :asc) }
   scope :by_created_at, -> { order(created_at: :desc) }
   scope :with_public, -> { where(public: true) }
+  scope :with_private_for_account, ->(account_id) { where("public = true OR (public = false AND account_id = ?)", account_id) }
   scope :with_course, ->(course_id) { where(course_id: course_id) }
   scope :with_cuisine, ->(cuisine_id) { where(cuisine_id: cuisine_id) }
   scope :search_for, ->(search) { where("title ilike ?", "%#{search}%") }

--- a/app/queries/recipe_index_query.rb
+++ b/app/queries/recipe_index_query.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+class RecipeIndexQuery
+  def initialize(relation = Recipe.all)
+    @relation = relation
+  end
+
+  def query(sort_by, user, search_query, course, cuisine)
+    @relation = if sort_by == "title"
+      @relation.by_title
+    else
+      @relation.by_created_at
+    end
+    if user.blank?
+      @relation = @relation.with_public
+    else
+      @relation = @relation.with_private_for_account(user.account)
+    end
+    @relation = @relation.search_for(search_query) if search_query
+    @relation = @relation.with_course(course) if course
+    @relation = @relation.with_cuisine(cuisine) if cuisine
+    @relation
+  end
+end

--- a/test/controllers/courses_controller_test.rb
+++ b/test/controllers/courses_controller_test.rb
@@ -7,7 +7,7 @@ class CoursesControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     sign_in users(:admin)
-    @course = courses(:one)
+    @course = courses(:unused)
   end
 
   test "should get index" do

--- a/test/controllers/cuisines_controller_test.rb
+++ b/test/controllers/cuisines_controller_test.rb
@@ -7,7 +7,7 @@ class CuisinesControllerTest < ActionDispatch::IntegrationTest
 
   setup do
     sign_in users(:admin)
-    @cuisine = cuisines(:one)
+    @cuisine = cuisines(:unused)
   end
 
   test "should get index" do

--- a/test/fixtures/courses.yml
+++ b/test/fixtures/courses.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
+  title: Main dish
 
 two:
-  title: MyString
+  title: Appetizer
+
+unused:
+  title: Unused

--- a/test/fixtures/cuisines.yml
+++ b/test/fixtures/cuisines.yml
@@ -1,7 +1,10 @@
 # Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
+  title: Mexican
 
 two:
-  title: MyString
+  title: Brazilian
+
+unused:
+  title: Unused

--- a/test/fixtures/recipes.yml
+++ b/test/fixtures/recipes.yml
@@ -6,6 +6,7 @@ one:
   public: false
   account: one
   slug: tortilla
+  cuisine: one
 
 two:
   title: Cake
@@ -13,3 +14,23 @@ two:
   public: false
   account: two
   slug: cake
+
+three:
+  title: Beans
+  info: MyText
+  public: true
+  account: two
+  slug: beans
+  created_at: 2018-01-01
+  cuisine: two
+  course: one
+
+four:
+  title: Guacamole
+  info: MyText
+  public: true
+  account: two
+  created_at: 2018-06-01
+  slug: guacamole
+  cuisine: one
+  course: two

--- a/test/queries/recipe_index_query_test.rb
+++ b/test/queries/recipe_index_query_test.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+class RecipeIndexQueryTest < ActiveSupport::TestCase
+  setup do
+    @account = accounts(:one)
+  end
+
+  test "Query without sort should return results sorted by newer first" do
+    user = nil
+    search_query = nil
+    course = nil
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query(nil, user, search_query, course, cuisine)
+
+    assert_equal 2, q.count
+    assert_equal recipes(:four), q.first
+    assert_equal recipes(:three), q.second
+  end
+
+  test "Query sorted by title should return ordered by title" do
+    user = nil
+    search_query = nil
+    course = nil
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query("title", user, search_query, course, cuisine)
+
+    assert_equal 2, q.count
+    assert_equal recipes(:three), q.first
+    assert_equal recipes(:four), q.second
+  end
+
+  test "Query without user should not return private recipes" do
+    sort_by = nil
+    user = nil
+    search_query = nil
+    course = nil
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query(sort_by, user, search_query, course, cuisine)
+
+    assert_equal 2, q.count
+    assert_not_includes q, recipes(:one)
+    assert_not_includes q, recipes(:two)
+  end
+
+  test "Query with user should not return private recipes from other users" do
+    sort_by = nil
+    user = accounts(:one).user
+    search_query = nil
+    course = nil
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query(sort_by, user, search_query, course, cuisine)
+
+    assert_equal 3, q.count
+    assert_not_includes q, recipes(:two)
+  end
+
+  test "Query with search query should return recipes where the partial term appears in the title" do
+    sort_by = nil
+    user = nil
+    search_query = 'guac'
+    course = nil
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query(sort_by, user, search_query, course, cuisine)
+
+    assert_equal 1, q.count
+    assert_equal recipes(:four), q.first
+  end
+
+  test "Query with cuisine should return only results with that cuisine" do
+    sort_by = nil
+    user = nil
+    search_query = nil
+    course = nil
+    cuisine = cuisines(:one)
+
+    q = RecipeIndexQuery.new.query(sort_by, user, search_query, course, cuisine)
+
+    assert_equal 1, q.count
+    assert_equal recipes(:four), q.first
+  end
+
+  test "Query with course should only return results with that course" do
+    sort_by = nil
+    user = nil
+    search_query = nil
+    course = courses(:one)
+    cuisine = nil
+
+    q = RecipeIndexQuery.new.query(sort_by, user, search_query, course, cuisine)
+
+    assert_equal 1, q.count
+    assert_equal recipes(:three), q.first
+  end
+end


### PR DESCRIPTION
The controller was showing recipes it should not be showing. This creates a new object which contains the query logic and add tests for each of the query possibilities.
Fixes #38.